### PR TITLE
feature/PLAT-1749 Fix gonfork tests

### DIFF
--- a/nfork/import.go
+++ b/nfork/import.go
@@ -12,12 +12,14 @@ import (
 func httpTransport(idleConnections int) *http.Transport {
 	return &http.Transport{
 		Proxy: http.ProxyFromEnvironment,
-		Dial: (&net.Dialer{
+		DialContext: (&net.Dialer{
 			Timeout:   30 * time.Second,
 			KeepAlive: 30 * time.Second,
-		}).Dial,
+			DualStack: true,
+		}).DialContext,
+		MaxIdleConns:        idleConnections,
+		IdleConnTimeout:     90 * time.Second,
 		TLSHandshakeTimeout: 10 * time.Second,
-		MaxIdleConnsPerHost: idleConnections,
 	}
 }
 

--- a/nfork/inbound.go
+++ b/nfork/inbound.go
@@ -282,7 +282,7 @@ func (inbound *Inbound) ServeHTTP(writer http.ResponseWriter, httpReq *http.Requ
 
 	for outbound, host := range inbound.Outbound {
 		if outbound != inbound.Active {
-			go inbound.forward(outbound, httpReq, host.Host, host.Path, body)
+			inbound.forward(outbound, httpReq, host.Host, host.Path, body)
 		} else {
 			activeHost = host.Host
 			activePath = host.Path

--- a/nfork/inbound_server.go
+++ b/nfork/inbound_server.go
@@ -7,8 +7,6 @@ import (
 
 	"net"
 	"net/http"
-	"sync/atomic"
-	"unsafe"
 )
 
 // InboundServer wraps an Inbound object into an HTTP server and allows the
@@ -18,7 +16,7 @@ import (
 // synchronized externally.
 type InboundServer struct {
 	listener net.Listener
-	inbound  unsafe.Pointer
+	inbound  *Inbound
 }
 
 // NewInboundServer creates and starts a new HTTP server associated with the
@@ -110,9 +108,9 @@ func (server *InboundServer) ActivateOutbound(outbound string) error {
 }
 
 func (server *InboundServer) setInbound(inbound *Inbound) {
-	atomic.StorePointer(&server.inbound, unsafe.Pointer(inbound))
+	server.inbound = inbound
 }
 
 func (server *InboundServer) getInbound() *Inbound {
-	return (*Inbound)(atomic.LoadPointer(&server.inbound))
+	return server.inbound
 }


### PR DESCRIPTION
This PR turns a goroutine call into a regular function call which (for some reason) fixes the failing tests. It also updates `import.go` to be `context`-aware and removes the use of `unsafe` pointers.

Figuring out why the `go ` breaks the tests is still TBD!

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nativetouch/gonfork/8)
<!-- Reviewable:end -->
